### PR TITLE
Fix broken GitHub link

### DIFF
--- a/themes/site-theme/layouts/_default/single.html
+++ b/themes/site-theme/layouts/_default/single.html
@@ -87,7 +87,7 @@
 
             {{ partial "single-about.html" . }}
 
-            <p>See something which isn't right? You can contribute to this page <a href="https://github.com/dnoberon/personal-blog" target="_blank">on GitHub</a> and we'll take care of it - Thanks for reading!</p>
+            <p>See something which isn't right? You can contribute to this page <a href="https://github.com/dnoberon/personal_blog" target="_blank">on GitHub</a> and we'll take care of it - Thanks for reading!</p>
 
             {{ if .Site.Params.enableDisqus }}
                 {{ partial "disqus.html" . }}


### PR DESCRIPTION
The only change is to the GitHub URL in the template.